### PR TITLE
Fix compiler warnings for freeing (const char*)

### DIFF
--- a/mux/src/object.cpp
+++ b/mux/src/object.cpp
@@ -507,9 +507,9 @@ dbref create_obj(dbref player, int objtype, const UTF8 *name, int cost)
     s_Owner(obj, (self_owned ? obj : owner));
     s_Pennies(obj, value);
     Unmark(obj);
-    pValidName = munge_space(pValidName);
-    s_Name(obj, pValidName);
-    free_lbuf(pValidName);
+    buff = munge_space(pValidName);
+    s_Name(obj, buff);
+    free_lbuf(buff); buff = NULL;
     db[obj].cpu_time_used.Set100ns(0);
 
     db[obj].tThrottleExpired.Set100ns(0);


### PR DESCRIPTION
pValidName is a const char*, so under alternative mux allocators (yes,
yes I know) this can produce warnings when things try to free memory
using it.

The original value of pValidName is not freed, as it really is (const
char_), and munge_space allocates a new LBUF for its munging.  s_Name
duplicates its input, so really all that needs freeing is the output of
munge_space, which the original code did.  It's the casting from char_
to const char\* that's problematic because it makes the free (via
pValidName) illegal under more direct allocator methods.

c.f. line 379 under the TYPE_PLAYER case, which handles this right--
using buff just like in this patch.
