### PR TITLE
tests: edge-case coverage for set ops and before/after (#757)

### DIFF
--- a/testcases/after_fn.mux
+++ b/testcases/after_fn.mux
@@ -20,11 +20,47 @@
         eq(strlen(after(foobar,-)), 0)
       )=
   {
-    @log smoke=TC001: after basic operations. Succeeded.;
+    @log smoke=TC001: after basic operations. Succeeded.
+  },
+  {
+    @log smoke=TC001: after basic operations. Failed (after(foo-bar%,-)=[after(foo-bar,-)] after(foobar%,-)=[after(foobar,-)]).
+  }
+-
+#
+# Test Case #2 - Separator position.  after() returns text following the
+# FIRST occurrence: the whole tail when the separator leads, empty when it
+# trails, and the remainder after the first match when the separator repeats.
+# A separator that is not present yields the empty string.
+#
+&tr.tc002 test_after_fn=
+  @if cand(
+        strmatch(after(-foobar,-), foobar),
+        eq(strlen(after(foobar-,-)), 0),
+        strmatch(after(a-b-c,-), b-c),
+        eq(strlen(after(abc,xyz)), 0)
+      )=
+  {
+    @log smoke=TC002: after separator position. Succeeded.
+  },
+  {
+    @log smoke=TC002: after separator position. Failed (lead=[after(-foobar,-)] trail=[after(foobar-,-)] first=[after(a-b-c,-)] none=[after(abc,xyz)]).
+  }
+-
+#
+# Test Case #3 - An empty separator defaults to a single space (and the
+# string is space-trimmed); multi-character separators are matched whole.
+#
+&tr.tc003 test_after_fn=
+  @if cand(
+        strmatch(after(hello world,), world),
+        strmatch(after(foo::bar,::), bar)
+      )=
+  {
+    @log smoke=TC003: after default and multichar. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC001: after basic operations. Failed (after(foo-bar%,-)=[after(foo-bar,-)] after(foobar%,-)=[after(foobar,-)]).;
+    @log smoke=TC003: after default and multichar. Failed (dflt=[after(hello world,)] multi=[after(foo::bar,::)]).;
     @trig me/tr.done
   }
 -

--- a/testcases/before_fn.mux
+++ b/testcases/before_fn.mux
@@ -20,11 +20,45 @@
         strmatch(before(foobar,-), foobar)
       )=
   {
-    @log smoke=TC001: before basic operations. Succeeded.;
+    @log smoke=TC001: before basic operations. Succeeded.
+  },
+  {
+    @log smoke=TC001: before basic operations. Failed (before(foo-bar%,-)=[before(foo-bar,-)] before(foobar%,-)=[before(foobar,-)]).
+  }
+-
+#
+# Test Case #2 - Separator position.  before() returns text up to the FIRST
+# occurrence: empty when the separator leads, the whole head when it trails,
+# and only the first segment when the separator repeats.
+#
+&tr.tc002 test_before_fn=
+  @if cand(
+        eq(strlen(before(-foobar,-)), 0),
+        strmatch(before(foobar-,-), foobar),
+        strmatch(before(a-b-c,-), a)
+      )=
+  {
+    @log smoke=TC002: before separator position. Succeeded.
+  },
+  {
+    @log smoke=TC002: before separator position. Failed (lead=[before(-foobar,-)] trail=[before(foobar-,-)] first=[before(a-b-c,-)]).
+  }
+-
+#
+# Test Case #3 - An empty separator defaults to a single space (and the
+# string is space-trimmed); multi-character separators are matched whole.
+#
+&tr.tc003 test_before_fn=
+  @if cand(
+        strmatch(before(hello world,), hello),
+        strmatch(before(foo::bar,::), foo)
+      )=
+  {
+    @log smoke=TC003: before default and multichar. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC001: before basic operations. Failed (before(foo-bar%,-)=[before(foo-bar,-)] before(foobar%,-)=[before(foobar,-)]).;
+    @log smoke=TC003: before default and multichar. Failed (dflt=[before(hello world,)] multi=[before(foo::bar,::)]).;
     @trig me/tr.done
   }
 -

--- a/testcases/setdiff_fn.mux
+++ b/testcases/setdiff_fn.mux
@@ -20,11 +20,45 @@
         strmatch(setdiff(a|b|c|d,b|d,|), a|c)
       )=
   {
-    @log smoke=TC001: setdiff basic operations. Succeeded.;
+    @log smoke=TC001: setdiff basic operations. Succeeded.
+  },
+  {
+    @log smoke=TC001: setdiff basic operations. Failed (setdiff=[setdiff(a b c d,b d)] setdiff|=[setdiff(a|b|c|d,b|d,|)]).
+  }
+-
+#
+# Test Case #2 - Set difference (list1 minus list2).  An empty list2 leaves
+# list1 (sorted, de-duplicated); an empty list1, or removing everything,
+# yields the empty set.
+#
+&tr.tc002 test_setdiff_fn=
+  @if cand(
+        strmatch(setdiff(a b c,), a b c),
+        eq(strlen(setdiff(,a b)), 0),
+        eq(strlen(setdiff(a b,a b)), 0)
+      )=
+  {
+    @log smoke=TC002: setdiff empty operands. Succeeded.
+  },
+  {
+    @log smoke=TC002: setdiff empty operands. Failed (l2empty=[setdiff(a b c,)] l1empty=[setdiff(,a b)] allgone=[setdiff(a b,a b)]).
+  }
+-
+#
+# Test Case #3 - Duplicates in list1 collapse to one; the kept elements come
+# out in ASCII sort order (so "10" precedes "2").
+#
+&tr.tc003 test_setdiff_fn=
+  @if cand(
+        strmatch(setdiff(a a b c d,b d), a c),
+        strmatch(setdiff(2 10 1,1), 10 2)
+      )=
+  {
+    @log smoke=TC003: setdiff duplicates and sort. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC001: setdiff basic operations. Failed (setdiff=[setdiff(a b c d,b d)] setdiff|=[setdiff(a|b|c|d,b|d,|)]).;
+    @log smoke=TC003: setdiff duplicates and sort. Failed (dups=[setdiff(a a b c d,b d)] sort=[setdiff(2 10 1,1)]).;
     @trig me/tr.done
   }
 -

--- a/testcases/setinter_fn.mux
+++ b/testcases/setinter_fn.mux
@@ -20,11 +20,44 @@
         strmatch(setinter(a|b|c,b|c|d,|), b|c)
       )=
   {
-    @log smoke=TC001: setinter basic operations. Succeeded.;
+    @log smoke=TC001: setinter basic operations. Succeeded.
+  },
+  {
+    @log smoke=TC001: setinter basic operations. Failed (setinter=[setinter(a b c,b c d)] setinter|=[setinter(a|b|c,b|c|d,|)]).
+  }
+-
+#
+# Test Case #2 - Disjoint lists and an empty operand yield the empty set; two
+# equal lists intersect to themselves (sorted, de-duplicated).
+#
+&tr.tc002 test_setinter_fn=
+  @if cand(
+        eq(strlen(setinter(a b,c d)), 0),
+        eq(strlen(setinter(,a b)), 0),
+        strmatch(setinter(a b c,a b c), a b c)
+      )=
+  {
+    @log smoke=TC002: setinter disjoint and empty. Succeeded.
+  },
+  {
+    @log smoke=TC002: setinter disjoint and empty. Failed (disjoint=[setinter(a b,c d)] empty=[setinter(,a b)] full=[setinter(a b c,a b c)]).
+  }
+-
+#
+# Test Case #3 - Duplicates collapse to one; the common elements come out
+# in ASCII sort order (so "10" precedes "2").
+#
+&tr.tc003 test_setinter_fn=
+  @if cand(
+        strmatch(setinter(a a b c,a b b), a b),
+        strmatch(setinter(2 10 1,1 2 10), 1 10 2)
+      )=
+  {
+    @log smoke=TC003: setinter duplicates and sort. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC001: setinter basic operations. Failed (setinter=[setinter(a b c,b c d)] setinter|=[setinter(a|b|c,b|c|d,|)]).;
+    @log smoke=TC003: setinter duplicates and sort. Failed (dups=[setinter(a a b c,a b b)] sort=[setinter(2 10 1,1 2 10)]).;
     @trig me/tr.done
   }
 -

--- a/testcases/setunion_fn.mux
+++ b/testcases/setunion_fn.mux
@@ -20,11 +20,61 @@
         strmatch(setunion(a|b|c,b|c|d,|), a|b|c|d)
       )=
   {
-    @log smoke=TC001: setunion basic operations. Succeeded.;
+    @log smoke=TC001: setunion basic operations. Succeeded.
+  },
+  {
+    @log smoke=TC001: setunion basic operations. Failed (setunion=[setunion(a b c,b c d)] setunion|=[setunion(a|b|c,b|c|d,|)]).
+  }
+-
+#
+# Test Case #2 - Empty inputs.  An empty operand contributes nothing; the
+# result is the sorted, de-duplicated other list (or empty when both are).
+#
+&tr.tc002 test_setunion_fn=
+  @if cand(
+        strmatch(setunion(,a b c), a b c),
+        strmatch(setunion(a b c,), a b c),
+        eq(strlen(setunion(,)), 0)
+      )=
+  {
+    @log smoke=TC002: setunion empty inputs. Succeeded.
+  },
+  {
+    @log smoke=TC002: setunion empty inputs. Failed (l1empty=[setunion(,a b c)] l2empty=[setunion(a b c,)] both=[setunion(,)]).
+  }
+-
+#
+# Test Case #3 - Duplicates are removed, within and across both lists; two
+# identical single-element lists collapse to one element.
+#
+&tr.tc003 test_setunion_fn=
+  @if cand(
+        strmatch(setunion(c a b a,b c), a b c),
+        strmatch(setunion(a,a), a)
+      )=
+  {
+    @log smoke=TC003: setunion duplicates. Succeeded.
+  },
+  {
+    @log smoke=TC003: setunion duplicates. Failed (dups=[setunion(c a b a,b c)] same=[setunion(a,a)]).
+  }
+-
+#
+# Test Case #4 - Default sort is ASCII (so "10" precedes "2"); the fifth arg
+# selects numeric sort; the fourth arg overrides the output separator.
+#
+&tr.tc004 test_setunion_fn=
+  @if cand(
+        strmatch(setunion(2 10 1,3), 1 10 2 3),
+        strmatch(setunion(2 10 1,3,,,n), 1 2 3 10),
+        strmatch(setunion(a b,c d,%b,-), a-b-c-d)
+      )=
+  {
+    @log smoke=TC004: setunion sort and osep. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC001: setunion basic operations. Failed (setunion=[setunion(a b c,b c d)] setunion|=[setunion(a|b|c,b|c|d,|)]).;
+    @log smoke=TC004: setunion sort and osep. Failed (ascii=[setunion(2 10 1,3)] numeric=[setunion(2 10 1,3,,,n)] osep=[setunion(a b,c d,%b,-)]).;
     @trig me/tr.done
   }
 -


### PR DESCRIPTION
Part of #757 (most `*_fn.mux` files have a single happy-path case).

Hardens two cohesive function families with boundary / empty / duplicate / sort / separator-position / not-found cases that lock down the documented semantics. Each expected value was derived from the implementation (`handle_sets`, `fun_before`/`fun_after`) and confirmed against the live server.

## `setunion` / `setinter` / `setdiff`
- **Empty operands** — one side empty, both empty, and removing everything.
- **Duplicates** — removed within and across both lists; two identical single-element lists collapse to one.
- **Sort & separators** — default sort is **ASCII** (so `10` precedes `2`); the 5th arg selects numeric sort; the 4th arg overrides the output separator.

## `before` / `after`
- **Separator position** — leading / trailing / repeated (first-occurrence): `before()` returns the head, `after()` the tail.
- **Separator absent** — `before()` returns the whole string, `after()` returns empty.
- **Empty separator** defaults to a single space (with space-trim); **multi-character** separators match whole.

+11 cases across 5 files. Smoke **1090/0/0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)