### PR TITLE
Handle Windows logoff in GANL console shutdown

### DIFF
--- a/mux/src/ganl_adapter.cpp
+++ b/mux/src/ganl_adapter.cpp
@@ -39,6 +39,7 @@ static BOOL WINAPI ConsoleCtrlHandler(DWORD dwCtrlType)
     case CTRL_C_EVENT:
     case CTRL_CLOSE_EVENT:
     case CTRL_BREAK_EVENT:
+    case CTRL_LOGOFF_EVENT:
     case CTRL_SHUTDOWN_EVENT:
         g_shutdown_flag = 1;
         return TRUE;


### PR DESCRIPTION
Opened PR #844 with the small GANL fix.

It only changes `mux/src/ganl_adapter.cpp` and adds `CTRL_LOGOFF_EVENT` to the existing Windows `ConsoleCtrlHandler` shutdown path.

No `platform.cpp` changes, no second `SetConsoleCtrlHandler` path, no `IPlatform` refactor.

Validation included in the PR body:

- `make -C src netmux-ganl_adapter.o` from `mux/`: OK.
- Full local `make` is still blocked by the existing local Google Drive path/rpath issue, not by this patch.