### PR TITLE
test: add RTL Unicode smoke coverage

### DIFF
--- a/testcases/strlen_fn.mux
+++ b/testcases/strlen_fn.mux
@@ -75,11 +75,30 @@
         eq(strlen(A[chr(127482)][chr(127480)]B), 3)
       )=
   {
-    @log smoke=TC004: strlen emoji clusters. Succeeded.;
+    @log smoke=TC004: strlen emoji clusters. Succeeded.
+  },
+  {
+    @log smoke=TC004: strlen emoji clusters. Failed (tone=[strlen([chr(128077)][chr(127997)])] flag=[strlen([chr(127482)][chr(127480)])] twoflag=[strlen([chr(127482)][chr(127480)][chr(127467)][chr(127479)])]).
+  }
+-
+#
+# Test Case #5 - RTL Hebrew and Arabic characters.
+# Hebrew letters and Arabic letters count as one grapheme each.  Arabic Fatha
+# is a combining mark and stays in the same grapheme cluster as its base.
+#
+&tr.tc005 test_strlen_fn=
+  @if cand(
+        eq(strlen([chr(1488)][chr(1489)][chr(1490)]), 3),
+        eq(strlen([chr(1587)][chr(1604)][chr(1575)][chr(1605)]), 4),
+        eq(strlen([chr(1605)][chr(1614)]), 1),
+        eq(strlen(A[chr(1488)]B), 3)
+      )=
+  {
+    @log smoke=TC005: strlen RTL Hebrew and Arabic. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC004: strlen emoji clusters. Failed (tone=[strlen([chr(128077)][chr(127997)])] flag=[strlen([chr(127482)][chr(127480)])] twoflag=[strlen([chr(127482)][chr(127480)][chr(127467)][chr(127479)])]).;
+    @log smoke=TC005: strlen RTL Hebrew and Arabic. Failed (he=[strlen([chr(1488)][chr(1489)][chr(1490)])] ar=[strlen([chr(1587)][chr(1604)][chr(1575)][chr(1605)])] arcomb=[strlen([chr(1605)][chr(1614)])] mixed=[strlen(A[chr(1488)]B)]).;
     @trig me/tr.done
   }
 -

--- a/testcases/vwidth_fn.mux
+++ b/testcases/vwidth_fn.mux
@@ -88,11 +88,29 @@
         eq(vwidth([chr(127482)][chr(127480)]ok),4)
       )=
   {
-    @log smoke=TC005: emoji clusters. Succeeded.;
+    @log smoke=TC005: emoji clusters. Succeeded.
+  },
+  {
+    @log smoke=TC005: emoji clusters. Failed (tone=[vwidth([chr(128077)][chr(127997)])] flag=[vwidth([chr(127482)][chr(127480)])] twoflag=[vwidth([chr(127482)][chr(127480)][chr(127467)][chr(127479)])]).
+  }
+-
+#
+# Test Case #6 - RTL Hebrew and Arabic characters are narrow, while Arabic
+# combining marks add no extra columns.
+#
+&tr.tc006 test_vwidth_fn=
+  @if cand(
+        eq(vwidth([chr(1488)][chr(1489)][chr(1490)]),3),
+        eq(vwidth([chr(1587)][chr(1604)][chr(1575)][chr(1605)]),4),
+        eq(vwidth([chr(1605)][chr(1614)]),1),
+        eq(vwidth(A[chr(1488)]B),3)
+      )=
+  {
+    @log smoke=TC006: RTL Hebrew and Arabic width. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC005: emoji clusters. Failed (tone=[vwidth([chr(128077)][chr(127997)])] flag=[vwidth([chr(127482)][chr(127480)])] twoflag=[vwidth([chr(127482)][chr(127480)][chr(127467)][chr(127479)])]).;
+    @log smoke=TC006: RTL Hebrew and Arabic width. Failed (he=[vwidth([chr(1488)][chr(1489)][chr(1490)])] ar=[vwidth([chr(1587)][chr(1604)][chr(1575)][chr(1605)])] arcomb=[vwidth([chr(1605)][chr(1614)])] mixed=[vwidth(A[chr(1488)]B)]).;
     @trig me/tr.done
   }
 -


### PR DESCRIPTION
## Summary
Adds minimal RTL Unicode smoke coverage for `strlen()` and `vwidth()`.

Covers Hebrew letters, Arabic letters, an Arabic base letter plus Fatha combining mark, and a mixed LTR/RTL string using the existing `chr(...)` test style.

Closes #847.
Partially addresses #756.

## Scope
Testcases only.
No runtime code changes.
No `strdistance_fn.mux` changes in this slice.

## Validation
- Clean worktree created from `origin/master` before editing.
- Expected values derived from this tree via local `muxscript` probe.
- Sanity-checked against the Unicode 16.0.0 tables in this tree: Hebrew/Arabic letters are East Asian Width `N`; Arabic Fatha is `Mn` and Grapheme Break `Extend`.
- `CPPFLAGS="-I/opt/homebrew/include" LDFLAGS="-L/opt/homebrew/lib" ./testcases/tools/Build.sh`: OK.
- Selected `strlen_fn` and `vwidth_fn` smoke runs executed with `Failed: 0`; the selected-suite wrapper exits nonzero due to its completeness check comparing against the full static suite list.
- Full smoke run: `Succeeded: 1266`, `Failed: 0`, `Crashes: 0`, `Dispatched: 262 / 262 expected`.
- `git diff --check`: OK.