### PR TITLE
test: add malformed syntax smoke coverage

### DIFF
--- a/testcases/malformed_syntax.mux
+++ b/testcases/malformed_syntax.mux
@@ -1,0 +1,69 @@
+#
+# malformed_syntax.mux - Test Cases for malformed softcode syntax.
+#
+@create test_malformed_syntax
+-
+@set test_malformed_syntax=INHERIT QUIET
+-
+#
+# Beginning of Test Cases
+#
+&tr.tc000 test_malformed_syntax=
+  @log smoke=Beginning malformed syntax test cases.
+-
+#
+# Test Case #1 - Incomplete sort() call reports stable arity rejection.
+#
+&tr.tc001 test_malformed_syntax=
+  @if strmatch(
+        eval(\[sort()\]),
+        #-1 FUNCTION (SORT) EXPECTS BETWEEN 1 AND 4 ARGUMENTS
+      )=
+  {
+    @log smoke=TC001: malformed sort call arity rejection. Succeeded.
+  },
+  {
+    @log smoke=TC001: malformed sort call arity rejection. Failed ([eval(\[sort()\])]).
+  }
+-
+#
+# Test Case #2 - Incomplete add() call reports stable arity rejection.
+#
+&tr.tc002 test_malformed_syntax=
+  @if strmatch(
+        eval(\[add()\]),
+        #-1 FUNCTION (ADD) EXPECTS BETWEEN 1 AND 100 ARGUMENTS
+      )=
+  {
+    @log smoke=TC002: malformed add call arity rejection. Succeeded.
+  },
+  {
+    @log smoke=TC002: malformed add call arity rejection. Failed ([eval(\[add()\])]).
+  }
+-
+#
+# Test Case #3 - Incomplete switch() call reports stable arity rejection.
+#
+&tr.tc003 test_malformed_syntax=
+  @if strmatch(
+        eval(\[switch()\]),
+        #-1 FUNCTION (SWITCH) EXPECTS BETWEEN 2 AND 100 ARGUMENTS
+      )=
+  {
+    @log smoke=TC003: malformed switch call arity rejection. Succeeded.;
+    @trig me/tr.done
+  },
+  {
+    @log smoke=TC003: malformed switch call arity rejection. Failed ([eval(\[switch()\])]).;
+    @trig me/tr.done
+  }
+-
+&tr.done test_malformed_syntax=
+  @log smoke=End malformed syntax test cases.;
+  @notify smoke
+-
+drop test_malformed_syntax
+-
+#
+# End of Test Cases
+#


### PR DESCRIPTION
## Summary
Closes #851.

Adds a tiny smoke test file for the first narrow malformed-softcode slice: incomplete function-call forms that produce stable, softcode-visible arity rejection.

Covered cases:
- `eval(\[sort()\])`
- `eval(\[add()\])`
- `eval(\[switch()\])`

Each case checks the current canonical `#-1 FUNCTION (...) EXPECTS ... ARGUMENTS` result from this tree.

Partially addresses #756.

## Scope
Test coverage only.
No runtime behavior changes.

This PR intentionally does not cover unmatched brackets, unmatched parentheses, malformed braces, nested-depth behavior, or literal/partial-evaluation compatibility fallback behavior. Recon showed those forms often return compatibility/literal output rather than clean rejection, so they should be handled separately if needed.

## Validation
- `MAKEFLAGS="ACLOCAL=aclocal AUTOMAKE=automake" CPPFLAGS="-I/opt/homebrew/include" LDFLAGS="-L/opt/homebrew/lib" ./testcases/tools/Build.sh`: OK.
- `bash ./tools/Makesmoke --workspace /private/tmp/tinymux-smoke-malformed --output /private/tmp/tinymux-smoke-malformed/smoke.flat malformed_syntax shutdown`: OK.
- `bash ./tools/Smoke --workspace /private/tmp/tinymux-smoke-malformed --flatfile /private/tmp/tinymux-smoke-malformed/smoke.flat`: OK, all 3 selected tests passed.
- `git diff --check`: OK.

Notes:
- The selected Makesmoke run emitted the existing `parser_fn.mux:132` digit-alpha warning while scanning testcases; this is unrelated to the new testcase.
- Full smoke was not run because the selected `malformed_syntax shutdown` subset was conclusive.
