### PR TITLE
test: add nested recursion-limit smoke coverage

### DIFF
--- a/testcases/nested_depth.mux
+++ b/testcases/nested_depth.mux
@@ -1,0 +1,61 @@
+#
+# nested_depth.mux - Test Cases for nested function recursion-limit behavior.
+#
+@create test_nested_depth
+-
+@set test_nested_depth=INHERIT QUIET
+-
+#
+# config(function_recursion_limit) is publicly readable, but changing/restoring
+# function_recursion_limit is CA_GOD-settable. The normal smoke harness runs as #1.
+# Capture the pre-test value and restore it unconditionally before assertions.
+# Keep setup/probe/restore in one queued @switch action list. @switch captures
+# the pre-test limit as #$, and the restore uses #$ directly so it cannot race
+# the queued PRE_LIMIT attribute store.
+# Do not test the hard evaluator stack guard here; its stable observable is no crash.
+#
+@switch [config(function_recursion_limit)]=*,
+  {
+    &PRE_LIMIT test_nested_depth=#$;
+    @admin function_recursion_limit=5;
+    &R3 test_nested_depth=[cat(cat(cat(fdepth())))];
+    &R4 test_nested_depth=[cat(cat(cat(cat(fdepth()))))];
+    @admin function_recursion_limit=#$
+  }
+-
+#
+# Beginning of Test Cases
+#
+&tr.tc000 test_nested_depth=
+  @log smoke=Beginning nested recursion-limit test cases.
+-
+#
+# Test Case #1 - Near-limit nesting succeeds and over-limit nesting fails visibly.
+#
+&tr.tc001 test_nested_depth=
+  @wait 0.2=
+  {
+    @if cand(
+          eq(get(test_nested_depth/R3),4),
+          strmatch(get(test_nested_depth/R4), #-1 FUNCTION RECURSION LIMIT EXCEEDED),
+          strmatch(config(function_recursion_limit), get(test_nested_depth/PRE_LIMIT))
+        )=
+    {
+      @log smoke=TC001: nested recursion-limit probes restored config and matched expected results. Succeeded.;
+      @trig me/tr.done
+    },
+    {
+      @log smoke=TC001: nested recursion-limit probes failed (pre=[get(test_nested_depth/PRE_LIMIT)] r3=[get(test_nested_depth/R3)] r4=[get(test_nested_depth/R4)] current=[config(function_recursion_limit)]).;
+      @trig me/tr.done
+    }
+  }
+-
+&tr.done test_nested_depth=
+  @log smoke=End nested recursion-limit test cases.;
+  @notify smoke
+-
+drop test_nested_depth
+-
+#
+# End of Test Cases
+#


### PR DESCRIPTION
Closes #853.

Partially addresses #756.

## Summary

This adds a focused smoke-test slice for nested function recursion-limit behavior.

The test:

- captures the original `function_recursion_limit` with `config(function_recursion_limit)`;
- temporarily lowers the limit to `5`;
- captures the near-limit probe result from `cat(cat(cat(fdepth())))`;
- captures the over-limit probe result from `cat(cat(cat(cat(fdepth()))))`;
- restores the captured original limit unconditionally before smoke assertions run;
- asserts the captured probe values and final restored config state.

The setup/probe/restore sequence is kept inside one queued `@switch` action list. `@switch` captures the pre-test limit as `#$`, and the restore uses `#$` directly rather than reading back the stored `PRE_LIMIT` attribute. That avoids the upload-time race where a plain top-level `@switch` store can still be queued while later immediate stdin commands continue executing.

The committed slice intentionally avoids the hard evaluator stack-guard path. That path's stable smoke-test observable is no crash / empty output rather than a stable softcode-visible error.

## Validation

Selected smoke subset:

```sh
cd testcases && ./tools/Makesmoke nested_depth shutdown && ./tools/Smoke
```

Result:

```text
Succeeded: 1
Failed:    0
Crashes:   0
Dispatched: 2 / 2 expected
Smoke: ALL 1 TESTS PASSED
```

Full smoke with `nested_depth.mux` present:

```text
Succeeded: 1262
Failed:    1
Crashes:   0
Dispatched: 265 / 265 expected
Failed test: TC003: switch  pattern scoping. Failed (actual=.MATCHED.).
```

Baseline full smoke with `nested_depth.mux` temporarily removed:

```text
Succeeded: 1261
Failed:    1
Crashes:   0
Dispatched: 264 / 264 expected
Failed test: TC003: switch  pattern scoping. Failed (actual=.MATCHED.).
```

So this slice introduces no additional full-suite failures in this local environment. The earlier 25 downstream failures in `route_fn` and `permission_paths` were caused by the upload-time `@switch` queue race and are resolved by the single-action-list restore-from-`#$` fix.
