### PR TITLE
test: add max argument-count boundary coverage

### DIFF
--- a/testcases/extract_fn.mux
+++ b/testcases/extract_fn.mux
@@ -134,7 +134,7 @@
   }
 -
 #
-# Test Case #8 - Walk single-hyphens through elements.
+# Test Case #8 - Walk single-hyphens through elements and arity boundary.
 #
 &tr.tc008 test_extract_fn=
   @if cand(
@@ -142,14 +142,15 @@
         strmatch(extract(a-b-c-d-e-f-g-h,4,2,-), d-e),
         strmatch(extract(a-b-c-d-e-f-g-h,8,1,-), h),
         strmatch(extract(-a-b-c-d-e-f-g-h,2,1,-), a),
-        strmatch(extract(a--b-c-d-e-f-g-h,3,1,-), b)
+        strmatch(extract(a--b-c-d-e-f-g-h,3,1,-), b),
+        strmatch(extract(a-b-c,1,1,-,|,extra), #-1 FUNCTION (EXTRACT) EXPECTS BETWEEN 3 AND 5 ARGUMENTS)
       )=
   {
     @log smoke=TC008: extract walk single-hyphens through elements. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC008: extract walk single-hyphens through elements. Failed.;
+    @log smoke=TC008: extract walk single-hyphens through elements. Failed (extract(over-max)=[extract(a-b-c,1,1,-,|,extra)]).;
     @trig me/tr.done
   }
 -

--- a/testcases/member_fn.mux
+++ b/testcases/member_fn.mux
@@ -44,20 +44,21 @@
   }
 -
 #
-# Test Case #3 - Custom delimiter and empty target word.
+# Test Case #3 - Custom delimiter, empty target word, and arity boundary.
 #
 &tr.tc003 test_member_fn=
   @if cand(
         eq(member(a|b|c,b,|), 2),
         eq(member(a:1|b:2|c:3,c:3,|), 3),
-        eq(member(a b c,), 0)
+        eq(member(a b c,), 0),
+        strmatch(member(a|b|c,b,|,extra), #-1 FUNCTION (MEMBER) EXPECTS 2 OR 3 ARGUMENTS)
       )=
   {
     @log smoke=TC003: member custom delimiter. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC003: member custom delimiter. Failed (member(a|b|c%,b%,|)=[member(a|b|c,b,|)] member(a:1|b:2|c:3%,c:3%,|)=[member(a:1|b:2|c:3,c:3,|)] member(a b c%,empty)=[member(a b c,)]).;
+    @log smoke=TC003: member custom delimiter. Failed (member(a|b|c%,b%,|)=[member(a|b|c,b,|)] member(a:1|b:2|c:3%,c:3%,|)=[member(a:1|b:2|c:3,c:3,|)] member(a b c%,empty)=[member(a b c,)] member(over-max)=[member(a|b|c,b,|,extra)]).;
     @trig me/tr.done
   }
 -

--- a/testcases/right_fn.mux
+++ b/testcases/right_fn.mux
@@ -41,20 +41,21 @@
   }
 -
 #
-# Test Case #3 - Negative count errors; non-numeric coerces to zero.
+# Test Case #3 - Negative count errors, non-numeric coercion, and arity boundary.
 #
 &tr.tc003 test_right_fn=
   @if cand(
         strmatch(right(abc,-1), #-1 OUT OF RANGE),
         eq(strlen(right(abc,foo)), 0),
-        eq(strlen(right(,3)), 0)
+        eq(strlen(right(,3)), 0),
+        strmatch(right(hello,3,x), #-1 FUNCTION (RIGHT) EXPECTS 2 ARGUMENTS)
       )=
   {
     @log smoke=TC003: right invalid counts. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC003: right invalid counts. Failed (right(abc%,-1)=[right(abc,-1)] right(abc%,foo)=[right(abc,foo)] right(%,3)=[right(,3)]).;
+    @log smoke=TC003: right invalid counts. Failed (right(abc%,-1)=[right(abc,-1)] right(abc%,foo)=[right(abc,foo)] right(%,3)=[right(,3)] right(over-max)=[right(hello,3,x)]).;
     @trig me/tr.done
   }
 -


### PR DESCRIPTION
Closes #855.

Partially addresses #756.

## Summary

Adds focused maximum argument-count smoke coverage for three representative arity error shapes:

- fixed arity: `RIGHT`, declared `2..2`
- adjacent range: `MEMBER`, declared `2..3`
- wider range: `EXTRACT`, declared `3..5`

Each assertion is added to the existing function-specific smoke file and extends an existing terminal `cand(...)` block so completion ordering stays unchanged.

## Covered cases

Fixed arity:

```mux
right(hello,3,x)
```

Expected result:

```text
#-1 FUNCTION (RIGHT) EXPECTS 2 ARGUMENTS
```

Adjacent range:

```mux
member(a|b|c,b,|,extra)
```

Expected result:

```text
#-1 FUNCTION (MEMBER) EXPECTS 2 OR 3 ARGUMENTS
```

Wider range:

```mux
extract(a-b-c,1,1,-,|,extra)
```

Expected result:

```text
#-1 FUNCTION (EXTRACT) EXPECTS BETWEEN 3 AND 5 ARGUMENTS
```

## Scope

#852 already covered zero-argument arity rejection for `sort()`, `add()`, and `switch()`. This PR intentionally does not re-cover zero-argument forms.

`MAX_ARG` variadic/sentinel functions such as `ADD`, `SWITCH`, and `CAT` are intentionally out of scope because excess parsed arguments may be concatenated, truncated, or otherwise handled without stable one-over-max rejection semantics.

`SORT` is also intentionally out of scope for this PR because #852 already covered its zero-arg arity string and `sort_fn.mux` already has 4-arg at-max style coverage.

`WORDPOS`, `MID`, and `REPEAT` remain out of scope for this slice.

## Validation

Selected smoke subsets:

```sh
cd testcases && ./tools/Makesmoke member_fn right_fn extract_fn shutdown && ./tools/Smoke
```

Result:

```text
Succeeded: 14
Failed:    0
Crashes:   0
Dispatched: 4 / 4 expected
Smoke: ALL 14 TESTS PASSED
```

Full smoke was also attempted locally:

```sh
cd testcases && ./tools/Makesmoke && ./tools/Smoke
```

Result in this local environment:

```text
Succeeded: 1262
Failed:    1
Crashes:   0
Dispatched: 265 / 265 expected
Failed test: TC003: switch  pattern scoping. Failed (actual=.MATCHED.).
```

The failure is in `switch`, not in `member_fn`, `right_fn`, or `extract_fn`; the selected touched subsets passed.

`git diff --check` passed.
