### PR TITLE
test: add repeat() LBUF-boundary smoke coverage

### DIFF
--- a/testcases/repeat_fn.mux
+++ b/testcases/repeat_fn.mux
@@ -5,6 +5,12 @@
 -
 @set test_repeat_fn=INHERIT QUIET
 -
+@switch [sub(config(lbuf_size),1)]=*,
+  {
+    &LBUF_MAX test_repeat_fn=#$;
+    &MAX_TIMES test_repeat_fn=[idiv(#$,2)]
+  }
+-
 #
 # Beginning of Test Cases
 #
@@ -28,21 +34,23 @@
   }
 -
 #
-# Test Case #2 - Zero, one, and empty-string cases.
+# Test Case #2 - Zero, one, empty-string, and LBUF-boundary cases.
 #
 &tr.tc002 test_repeat_fn=
   @if cand(
         eq(strlen(repeat(ab,0)),0),
         strmatch(repeat(ab,1),ab),
         eq(strlen(repeat(,5)),0),
-        eq(strlen(repeat(x,-1)),0)
+        eq(strlen(repeat(x,-1)),0),
+        eq(strlen(repeat(ab,[get(test_repeat_fn/MAX_TIMES)])),mul(get(test_repeat_fn/MAX_TIMES),2)),
+        strmatch(repeat(ab,[add(get(test_repeat_fn/MAX_TIMES),1)]),#-1 STRING TOO LONG)
       )=
   {
-    @log smoke=TC002: repeat zero and empty cases. Succeeded.;
+    @log smoke=TC002: repeat zero, empty, and LBUF-boundary cases. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC002: repeat zero and empty cases. Failed (repeat(ab%,0)=[repeat(ab,0)] repeat(ab%,1)=[repeat(ab,1)] repeat(,5)=[repeat(,5)] repeat(x%,-1)=[repeat(x,-1)]).;
+    @log smoke=TC002: repeat zero, empty, and LBUF-boundary cases. Failed (repeat(ab%,0) len=[strlen(repeat(ab,0))] repeat(ab%,1) len=[strlen(repeat(ab,1))] repeat(%,5) len=[strlen(repeat(,5))] repeat(x%,-1) len=[strlen(repeat(x,-1))] lbuf_max=[get(test_repeat_fn/LBUF_MAX)] max_times=[get(test_repeat_fn/MAX_TIMES)] atmax_len=[strlen(repeat(ab,[get(test_repeat_fn/MAX_TIMES)]))] over_len=[strlen(repeat(ab,[add(get(test_repeat_fn/MAX_TIMES),1)]))]).;
     @trig me/tr.done
   }
 -


### PR DESCRIPTION
Closes #860.

Partially addresses #756.

## Summary

- Add focused softcode-visible LBUF-boundary coverage for `repeat()`.
- Use `config(lbuf_size)` instead of a hardcoded `32768`/`32767`, so the assertion tracks the compiled tree value.
- Cover the direct multi-character `repeat()` boundary: near-limit success stays under `LBUF_SIZE - 1`, and one-over-limit returns `#-1 STRING TOO LONG`.

## Scope notes

- `strtrunc()` was considered and intentionally rejected for this slice because its truncation path is grapheme-cluster-based and Unicode-aware by design, which is outside #860's LBUF/string-boundary scope even with ASCII-only input.
- Single-character `repeat()` patterns are intentionally excluded because they route through `safe_fill()` and silently clamp/truncate rather than exercising the explicit `#-1 STRING TOO LONG` check.
- This does not touch #857; the `switch()` / `switchall()` AST-path issue remains separate.

## Validation

- `cd testcases && ./tools/Makesmoke repeat_fn shutdown && ./tools/Smoke`
  - Passed: 2 / 2 dispatched, 0 failures.
- `cd testcases && ./tools/Makesmoke && ./tools/Smoke`
  - Reproduced the known unrelated `switch` TC003/#857 failure: `TC003: switch  pattern scoping. Failed (actual=.MATCHED.)`.
  - No `repeat_fn` regression observed.
- `git diff --check`
