### PR TITLE
test: add ljust() width-boundary regression coverage

### DIFF
--- a/testcases/ljust_fn.mux
+++ b/testcases/ljust_fn.mux
@@ -130,10 +130,32 @@
       )=
   {
     @log smoke=TC007: color inside cluster truncation. Succeeded.;
+  },
+  {
+    @log smoke=TC007: color inside cluster truncation. Failed (plain=[encode64(stripansi(ljust([chr(128075)][chr(127995)]ab,3)))] col=[encode64(stripansi(ljust(strcat(ansi(r,chr(128075)),chr(127995),ab),3)))] vw=[vwidth(strcat(ansi(r,chr(128075)),chr(127995)))]).
+  }
+-
+#
+# Test Case #8 - LBUF width boundary regression guard (#860).
+# Commit b8f11142bc6bd507c3e7a6473174b02ba21789fc fixed a bug where
+# centerjustcombo() narrowed the parsed width to LBUF_OFFSET before checking
+# it against LBUF_SIZE, so far-over widths such as 999999 could wrap into
+# an apparently valid range.
+#
+&tr.tc008 test_ljust_fn=
+  @if cand(
+        eq(strlen(ljust(x,[sub(config(lbuf_size),1)])), sub(config(lbuf_size),1)),
+        strmatch(ljust(x,[config(lbuf_size)]), #-1 OUT OF RANGE),
+        strmatch(ljust(x,999999), #-1 OUT OF RANGE),
+        strmatch(ljust(x,-5), #-1 OUT OF RANGE),
+        eq(strlen(ljust(x,0)), 0)
+      )=
+  {
+    @log smoke=TC008: ljust LBUF width boundary regression guard. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC007: color inside cluster truncation. Failed (plain=[encode64(stripansi(ljust([chr(128075)][chr(127995)]ab,3)))] col=[encode64(stripansi(ljust(strcat(ansi(r,chr(128075)),chr(127995),ab),3)))] vw=[vwidth(strcat(ansi(r,chr(128075)),chr(127995)))]).;
+    @log smoke=TC008: ljust LBUF width boundary regression guard. Failed (atmax_len=[strlen(ljust(x,[sub(config(lbuf_size),1)]))] atlimit=[ljust(x,[config(lbuf_size)])] far=[ljust(x,999999)] neg=[ljust(x,-5)] zero_len=[strlen(ljust(x,0))]).;
     @trig me/tr.done
   }
 -


### PR DESCRIPTION
Closes #860.

Partially addresses #756.

## Summary

- Add focused `ljust()` smoke coverage for the LBUF width-boundary regression fixed in b8f11142bc6bd507c3e7a6473174b02ba21789fc.
- Cover the accepted max width with `config(lbuf_size) - 1`, the rejected `config(lbuf_size)` boundary, the literal far-over regression value `999999`, negative width rejection, and width `0`.
- Move the terminal `@trig me/tr.done` from `TC007` to the new `TC008` so the new assertion cannot be skipped.

## Scope notes

- `config(lbuf_size)` is used for the two LBUF_SIZE-relative cases instead of hardcoded `32768` / `32767`.
- `999999` is intentionally kept literal because its significance is the old 65536 wraparound modulus, not the current LBUF_SIZE.
- `rjust()` and `center()` share the same fixed `centerjustcombo()` implementation, so this PR covers the regression once via `ljust()` to keep the diff minimal.
- This does not touch #857 and is independent of the ~~still-open~~ already-closed PR #861.

## Validation

- `cd testcases && ./tools/Makesmoke ljust_fn shutdown && ./tools/Smoke`
  - Passed: 7 assertions, 0 failures.
- `cd testcases && ./tools/Makesmoke && ./tools/Smoke`
  - Reproduced the known unrelated #857 failure: `TC003: switch  pattern scoping. Failed (actual=.MATCHED.)`.
  - No `ljust_fn` regression observed.
- `git diff --check`
