### PR TITLE
test: add exp underflow smoke coverage

### DIFF
--- a/testcases/exp_fn.mux
+++ b/testcases/exp_fn.mux
@@ -28,20 +28,21 @@
   }
 -
 #
-# Test Case #2 - Inverse of ln, overflow to +Inf, coercion.
+# Test Case #2 - Inverse of ln, overflow to +Inf, underflow to zero, coercion.
 #
 &tr.tc002 test_exp_fn=
   @if cand(
         eq(round(exp(ln(7)),6), 7),
         strmatch(exp(1000), +Inf),
+        strmatch(exp(-1000), 0),
         eq(exp(foo), 1)
       )=
   {
-    @log smoke=TC002: exp inverse and overflow. Succeeded.;
+    @log smoke=TC002: exp inverse, overflow, and underflow. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC002: exp inverse and overflow. Failed (exp(ln(7))=[round(exp(ln(7)),6)] exp(1000)=[exp(1000)] exp(foo)=[exp(foo)]).;
+    @log smoke=TC002: exp inverse, overflow, and underflow. Failed (exp(ln(7))=[round(exp(ln(7)),6)] exp(1000)=[exp(1000)] exp(-1000)=[exp(-1000)] exp(foo)=[exp(foo)]).;
     @trig me/tr.done
   }
 -


### PR DESCRIPTION
Closes #863.

Partially addresses #756.

## Summary

- add the missing `exp()` floating-point underflow-to-zero smoke assertion
- keep the slice focused in `testcases/exp_fn.mux`
- extend the existing terminal TC002 instead of adding a new test case

## Notes

`testcases/overflow_inject_fn.mux` already represents the integer-boundary side: INT64 limits, arithmetic overflow, divide-by-zero, shifts, `inc()` / `dec()`, and `abs()` / `sign()` behavior.

`testcases/exp_fn.mux` already covers overflow via `exp(1000)` returning `+Inf`. This PR adds the matching underflow-to-zero side with `exp(-1000)` returning the canonical softcode-visible `0`.

Subnormal-edge cases such as `exp(-745)` are intentionally avoided because they are more platform/libm-sensitive. `exp(-1000)` is far below the subnormal boundary and is stable for this focused smoke slice.

Source-level review confirmed no JIT/interpreter formatting divergence for this function: the interpreter path, HIR constant folding, and RV64 JIT/DBT path all use the same `::exp()` libm call and `fval()` formatting path for the resulting double.

## Validation

Runtime artifacts were rebuilt from this branch before smoke validation via `make install`; `mux/game/bin/engine.so` and `libmux.so` pointed at this checkout, and `netmux` was freshly installed in `mux/game/bin`.

- `cd testcases && ./tools/Makesmoke exp_fn shutdown && ./tools/Smoke`: passed, 2/2 tests, 0 failures
- `cd testcases && ./tools/Makesmoke && ./tools/Smoke`: attempted on the same fresh runtime; failed with one unrelated current full-suite failure in `TC003: justify width parity` (`1263` succeeded, `1` failed, `265/265` dispatched)
- `git diff --check`: passed
