### PR TITLE
test: fix stale negative-width expectation in delim_parity_fn TC003

### DIFF
--- a/testcases/delim_parity_fn.mux
+++ b/testcases/delim_parity_fn.mux
@@ -61,10 +61,10 @@
 #
 # Test Case #3 - ljust/rjust/center width parsing parity (centerjustcombo):
 # "+3" is a valid integer (mux_atol), "3.5" is not (is_integer) and emits
-# nothing, widths at or past LBUF_SIZE are a range error, and a negative
-# width wraps through LBUF_OFFSET (uint16) — -1 wraps to 65535 (range
-# error), -40000 wraps to 25536 columns of padding.  The 25536 case also
-# guards the LBUF_SIZE=32768 libmux build and DBT NEGW correctness.
+# nothing, and any width that is negative or at/past LBUF_SIZE is a range
+# error (#860/#862: the width is range-checked as a long before narrowing
+# to LBUF_OFFSET, so large-magnitude negative values no longer wrap through
+# uint16 into a false-valid width).
 #
 &tr.tc003 test_delim_parity_fn=
   @if cand(
@@ -72,13 +72,13 @@
         eq(strlen(ljust(abcdef,3.5)), 0),
         strmatch(ljust(abc,40000), #-1 OUT OF RANGE),
         strmatch(rjust(abc,-1), #-1 OUT OF RANGE),
-        eq(strlen(rjust(abc,-40000)), 25536)
+        strmatch(rjust(abc,-40000), #-1 OUT OF RANGE)
       )=
   {
     @log smoke=TC003: justify width parity. Succeeded.;
   },
   {
-    @log smoke=TC003: justify width parity. Failed (plus=[ljust(abcdef,+3)] float=[ljust(abcdef,3.5)] big=[ljust(abc,40000)] neg1=[rjust(abc,-1)] wraplen=[strlen(rjust(abc,-40000))]).;
+    @log smoke=TC003: justify width parity. Failed (plus=[ljust(abcdef,+3)] float=[ljust(abcdef,3.5)] big=[ljust(abc,40000)] neg1=[rjust(abc,-1)] neg2=[rjust(abc,-40000)]).;
   }
 -
 #


### PR DESCRIPTION
Closes #865.

## Summary

- update `testcases/delim_parity_fn.mux` TC003 to match the post-#862 `centerjustcombo()` behavior
- replace the stale `rjust(abc,-40000)` wraparound-length expectation with `#-1 OUT OF RANGE`
- keep the change test-only; no runtime/source code changes

## Details

TC003 previously asserted the pre-#862 wraparound behavior for `rjust(abc,-40000)`, expecting the large negative width to narrow through `LBUF_OFFSET` into a false-valid width.

`centerjustcombo()` was fixed by #862 / b8f11142b to range-check the parsed width as a `long` before narrowing. Current behavior correctly rejects all negative widths, including `-40000`, with `#-1 OUT OF RANGE`.

This is not a JIT/Tier 2 parity issue: source review confirms `LJUST`, `RJUST`, and `CENTER` are registered as Tier 2 but are not active intrinsics yet, so these calls still route through the shared `centerjustcombo()` implementation.

## Validation

Runtime artifacts were rebuilt/verified fresh from this branch before smoke validation. I forced recompilation of the relevant engine path and ran `make install`; `mux/game/bin/engine.so` and `libmux.so` pointed at this checkout, and `netmux` was freshly installed in `mux/game/bin`.

- `cd testcases && ./tools/Makesmoke delim_parity_fn shutdown && ./tools/Smoke`: passed, 7/7 tests, 0 failures
- `cd testcases && ./tools/Makesmoke && ./tools/Smoke`: passed, 1264/1264 tests, 0 failures, 265/265 suites dispatched
- `git diff --check`: passed
