### PR TITLE
test: add squish empty-input smoke coverage

### DIFF
--- a/testcases/squish_fn.mux
+++ b/testcases/squish_fn.mux
@@ -27,19 +27,21 @@
   }
 -
 #
-# Test Case #2 - Two-character separators.
+# Test Case #2 - Two-character separators and empty input.
 #
 &tr.tc002 test_squish_fn=
   @if cand(
         strmatch(squish(ABABCCAB,AB), ABCCAB),
-        gt(strlen(squish(%r%rFoo%r%rBar%r%r,%r)), 0)
+        gt(strlen(squish(%r%rFoo%r%rBar%r%r,%r)), 0),
+        eq(strlen(squish()), 0),
+        eq(strlen(squish(,)), 0)
       )=
   {
-    @log smoke=TC002: Two-character separators. Succeeded.;
+    @log smoke=TC002: Two-character separators and empty input. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC002: Two-character separators. Failed (squish(ABABCCAB%,AB)=[squish(ABABCCAB,AB)]).;
+    @log smoke=TC002: Two-character separators and empty input. Failed (squish(ABABCCAB%,AB)=[squish(ABABCCAB,AB)] squish()=[strlen(squish())] squish(%,)=[strlen(squish(,))]).;
     @trig me/tr.done
   }
 -


### PR DESCRIPTION
Closes #867.

Partially addresses #756.

## Summary

- add focused empty/no-input smoke coverage for `squish()`
- assert both omitted-input and explicit-empty-input forms return empty output
- fold the assertions into the existing terminal TC002 block without moving `@trig me/tr.done`

## Notes

`SQUISH` is declared with `minArgs=0`, so `squish()` is valid and is not a zero-argument arity rejection case. This slice intentionally stays separate from #852-style malformed/arity coverage.

The two added assertions exercise distinct paths:

- `squish()` covers omitted input and returns empty output.
- `squish(,)` covers explicit empty input and returns empty output through the normal compression path.

Both are asserted with `strlen(...) == 0` to avoid relying on visible empty-string formatting.

## Validation

Runtime artifacts were rebuilt/verified fresh from this branch before smoke validation. The branch is based on current `origin/master`, including `007ac80bc`; I rebuilt the relevant engine path and ran `make install`, with `mux/game/bin/engine.so` and `libmux.so` pointing at this checkout and `netmux` freshly installed in `mux/game/bin`.

- `cd testcases && ./tools/Makesmoke squish_fn shutdown && ./tools/Smoke`: passed, 2/2 tests, 0 failures
- `cd testcases && ./tools/Makesmoke && ./tools/Smoke`: passed, 1264/1264 tests, 0 failures, 265/265 suites dispatched
- `git diff --check`: passed
