### PR TITLE
test: add cos() non-numeric argument coercion coverage

### DIFF
--- a/testcases/cos_fn.mux
+++ b/testcases/cos_fn.mux
@@ -17,13 +17,14 @@
 &tr.tc001 test_cos_fn=
   @if cand(
         eq(round(cos(0),6), 1),
-        eq(round(cos(pi()),6), -1)
+        eq(round(cos(pi()),6), -1),
+        eq(round(cos(foo),6), 1)
       )=
   {
-    @log smoke=TC001: cos basic operations. Succeeded.
+    @log smoke=TC001: cos basic operations and non-numeric coercion. Succeeded.
   },
   {
-    @log smoke=TC001: cos basic operations. Failed (cos(0)=[round(cos(0),6)] cos(pi)=[round(cos(pi()),6)]).
+    @log smoke=TC001: cos basic operations and non-numeric coercion. Failed (cos(0)=[round(cos(0),6)] cos(pi)=[round(cos(pi()),6)] cos(foo)=[round(cos(foo),6)]).
   }
 -
 #


### PR DESCRIPTION
Closes #869.

Partially addresses #756.

## Summary

Adds one focused `cos()` smoke assertion for the existing non-numeric argument coercion behavior:

- `cos(foo)` coerces `foo` through `mux_atof()` to `0.0`;
- `cos(0.0)` evaluates to `1.0`;
- the assertion is folded into `cos_fn` TC001 as `eq(round(cos(foo),6), 1)`.

This is coverage of existing intentional coercion semantics, not an error or rejection path. It matches the already-present precedent in nearby math tests: `exp(foo) -> 1`, `sqrt(foo) -> 0`, and `ln(foo) -> -Inf`.

## Notes

- Added to TC001, not terminal TC002, because TC001 already covers basic cosine behavior around `cos(0)`.
- No `@trig me/tr.done` placement changes were needed.
- The tier2/RV64 softlib path was independently checked twice before implementation: `rv64_cos` is a thin pass-through using `rv64_strtod -> host mux_atof`, host libm `cos`, and `rv64_fval -> host fval`, so there is no separate drift-prone implementation for this case.
- Runtime validation used freshly rebuilt artifacts from this branch. `funmath.cpp` was touched timestamp-only before `make install`, which rebuilt and reinstalled `engine.so`.

## Validation

- `cd testcases && ./tools/Makesmoke cos_fn shutdown && ./tools/Smoke`
  - passed: 2/2 tests, 0 failures, 0 crashes
- `cd testcases && ./tools/Makesmoke && ./tools/Smoke`
  - passed: 1264/1264 tests, 0 failures, 0 crashes, 265/265 suites dispatched
- `git diff --check`
  - passed
