### PR TITLE
test: add right() Unicode grapheme-cluster coverage

### DIFF
--- a/testcases/right_fn.mux
+++ b/testcases/right_fn.mux
@@ -31,13 +31,15 @@
         eq(strlen(right(abc,0)), 0),
         strmatch(right(abc,3), abc),
         strmatch(right(abc,5), abc),
-        strmatch(right(abcdefgh,1), h)
+        strmatch(right(abcdefgh,1), h),
+        strmatch(right(ab[chr(128075)][chr(127995)],1), [chr(128075)][chr(127995)]),
+        eq(strlen(right(setr(0,ab[chr(128075)][chr(127995)]),1)), 1)
       )=
   {
-    @log smoke=TC002: right boundary lengths. Succeeded.
+    @log smoke=TC002: right boundary lengths and grapheme clusters. Succeeded.
   },
   {
-    @log smoke=TC002: right boundary lengths. Failed (right(abc%,0)=[right(abc,0)] right(abc%,3)=[right(abc,3)] right(abc%,5)=[right(abc,5)] right(abcdefgh%,1)=[right(abcdefgh,1)]).
+    @log smoke=TC002: right boundary lengths and grapheme clusters. Failed (right(abc%,0)=[right(abc,0)] right(abc%,3)=[right(abc,3)] right(abc%,5)=[right(abc,5)] right(abcdefgh%,1)=[right(abcdefgh,1)] cluster=[right(ab[chr(128075)][chr(127995)],1)] runtime_len=[strlen(right(setr(0,ab[chr(128075)][chr(127995)]),1))]).
   }
 -
 #


### PR DESCRIPTION
Closes #871.

Partially addresses #756.

## Summary

Adds right()-specific Unicode grapheme-cluster smoke coverage in `testcases/right_fn.mux`.

The new TC002 assertions cover:

- a constant-form exact-value check that `right(ab[chr(128075)][chr(127995)],1)` returns the intact skin-tone emoji grapheme cluster;
- a `setr()`-fed runtime companion that checks the returned value has grapheme length 1.

`right()` already uses the cluster-aware helper path (`co_cluster_count()` and `co_mid_cluster()`). The runtime-fed assertion is included because a constant-only form can be satisfied by host-side constant folding without exercising the tier2/JIT dispatch path.

## Notes

- This area had a real, now-fixed tier2 divergence in 612ce793f, which is already merged and is not part of this diff.
- `left()` is out of scope here because equivalent coverage already exists in `testcases/left_fn.mux` from abc60aecf.
- This PR does not touch runtime/source files.

## Validation

Fresh runtime artifacts were rebuilt from this branch with `make install` before smoke validation.

- `cd testcases && ./tools/Makesmoke right_fn shutdown && ./tools/Smoke`
  - passed: 3/3 tests, 0 failures, 0 crashes, 2/2 suites dispatched
- `cd testcases && ./tools/Makesmoke && ./tools/Smoke`
  - passed: 1266/1266 tests, 0 failures, 0 crashes, 266/266 suites dispatched
- `git diff --check`
  - passed

Branch base includes both prerequisite commits:

- 612ce793f (`fix: make tier2 left/right wrappers grapheme-cluster-aware`)
- abc60aecf (`refactor: make left() a first-class function; strtrunc() becomes its synonym`)
