### PR TITLE
test: add candbool/corbool short-circuit smoke coverage

### DIFF
--- a/testcases/candbool_fn.mux
+++ b/testcases/candbool_fn.mux
@@ -21,10 +21,25 @@
       )=
   {
     @log smoke=TC001: candbool() basic operations. Succeeded.;
-    @trig me/tr.done
   },
   {
     @log smoke=TC001: candbool() basic operations. Failed (candbool(1%,1%,1)=[candbool(1,1,1)] candbool(1%,0%,1)=[candbool(1,0,1)]).;
+  }
+-
+#
+# Test Case #2 - Short-circuit skips later arguments.
+#
+&tr.tc002 test_candbool_fn=
+  @if cand(
+        strmatch([setq(0,clear)][candbool(0,[setq(0,hit)]1)]:%q0, 0:clear),
+        strmatch([setq(1,clear)][candbool(1,[setq(1,hit)]1)]:%q1, 1:hit)
+      )=
+  {
+    @log smoke=TC002: candbool() short-circuit side effects. Succeeded.;
+    @trig me/tr.done
+  },
+  {
+    @log smoke=TC002: candbool() short-circuit side effects. Failed (skip=.[setq(0,clear)][candbool(0,[setq(0,hit)]1)]:%q0. eval=.[setq(1,clear)][candbool(1,[setq(1,hit)]1)]:%q1.).;
     @trig me/tr.done
   }
 -

--- a/testcases/corbool_fn.mux
+++ b/testcases/corbool_fn.mux
@@ -21,10 +21,25 @@
       )=
   {
     @log smoke=TC001: corbool() basic operations. Succeeded.;
-    @trig me/tr.done
   },
   {
     @log smoke=TC001: corbool() basic operations. Failed (corbool(0%,0%,0)=[corbool(0,0,0)] corbool(0%,1%,0)=[corbool(0,1,0)]).;
+  }
+-
+#
+# Test Case #2 - Short-circuit skips later arguments.
+#
+&tr.tc002 test_corbool_fn=
+  @if cand(
+        strmatch([setq(0,clear)][corbool(1,[setq(0,hit)]0)]:%q0, 1:clear),
+        strmatch([setq(1,clear)][corbool(0,[setq(1,hit)]1)]:%q1, 1:hit)
+      )=
+  {
+    @log smoke=TC002: corbool() short-circuit side effects. Succeeded.;
+    @trig me/tr.done
+  },
+  {
+    @log smoke=TC002: corbool() short-circuit side effects. Failed (skip=.[setq(0,clear)][corbool(1,[setq(0,hit)]0)]:%q0. eval=.[setq(1,clear)][corbool(0,[setq(1,hit)]1)]:%q1.).;
     @trig me/tr.done
   }
 -


### PR DESCRIPTION
Closes #876. Partially addresses #757.

Adds one TC002 to each of testcases/candbool_fn.mux and
testcases/corbool_fn.mux, pairing a skip case (side-effecting setq() argument
never runs when short-circuited, register stays a pre-set sentinel) with an
eval case (setq() fires and dirties the register when short-circuiting does
not apply). Proves candbool()/corbool() short-circuit mechanically, not just
by naming convention -- see #876 for full rationale and maintainer-verified
premises, including the JIT-lane structural preservation of the same
short-circuit via a per-argument block chain.

Validation: selected smoke (candbool_fn/corbool_fn/shutdown) 4/4 passed; full
smoke 1268/1268 passed, 266/266 suites dispatched, 0 failures, 0 crashes; git
diff --check clean.