### PR TITLE
test: add case() no-match smoke coverage

### DIFF
--- a/testcases/case_fn.mux
+++ b/testcases/case_fn.mux
@@ -17,14 +17,15 @@
 &tr.tc001 test_case_fn=
   @if cand(
         strmatch(case(2,1,one,2,two,default),two),
-        strmatch(case(5,1,one,2,two,default),default)
+        strmatch(case(5,1,one,2,two,default),default),
+        eq(strlen(case(abc,def,hit)),0)
       )=
   {
     @log smoke=TC001: case() basic operations. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC001: case() basic operations. Failed (case(2)=[case(2,1,one,2,two,default)] case(5)=[case(5,1,one,2,two,default)]).;
+    @log smoke=TC001: case() basic operations. Failed (case(2)=[case(2,1,one,2,two,default)] case(5)=[case(5,1,one,2,two,default)] case(nomatch)=[case(abc,def,hit)]).;
     @trig me/tr.done
   }
 -


### PR DESCRIPTION
Closes #879. Partially addresses #757.

Adds a no-match/no-default assertion to the existing TC001 in testcases/case_fn.mux, keeping the slice limited to case() coverage.

Validation: build succeeded; smoke 1268 succeeded / 0 failed / 0 crashes, 266/266 suites dispatched; git diff --check clean.