### PR TITLE
test: add switch() no-match smoke coverage

### DIFF
--- a/testcases/switch_fn.mux
+++ b/testcases/switch_fn.mux
@@ -19,14 +19,15 @@
 &tr.tc001 test_switch_fn=
   @if cand(
         strmatch(switch(foo,f*,found,default), found),
-        strmatch(switch(bar,f*,found,default), default)
+        strmatch(switch(bar,f*,found,default), default),
+        eq(strlen(switch(bar,f*,found)),0)
       )=
   {
     @log smoke=TC001: switch basic operations. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC001: switch basic operations. Failed (s1=[switch(foo,f*,found,default)] s2=[switch(bar,f*,found,default)]).;
+    @log smoke=TC001: switch basic operations. Failed (s1=[switch(foo,f*,found,default)] s2=[switch(bar,f*,found,default)] s3=[switch(bar,f*,found)]).;
     @trig me/tr.done
   }
 -


### PR DESCRIPTION
Closes #881. Partially addresses #757.

Adds a no-match/no-default assertion to the existing TC001 in testcases/switch_fn.mux, keeping the slice limited to switch() coverage.

Validation: build succeeded; smoke 1268 succeeded / 0 failed / 0 crashes, 266/266 suites dispatched; git diff --check clean.