### PR TITLE
test: add distance boundary smoke coverage

### DIFF
--- a/testcases/dist2d_fn.mux
+++ b/testcases/dist2d_fn.mux
@@ -17,14 +17,18 @@
 &tr.tc001 test_dist2d_fn=
   @if cand(
         eq(dist2d(0,0,3,4),5),
-        eq(dist2d(1,1,4,5),5)
+        eq(dist2d(1,1,4,5),5),
+        eq(dist2d(0,0,0,0),0),
+        eq(dist2d(-3,-4,0,0),5),
+        strmatch(dist2d(0,0,1,1),1.4142135623730951),
+        eq(dist2d(1,2,5,6),dist2d(5,6,1,2))
       )=
   {
     @log smoke=TC001: dist2d() basic operations. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC001: dist2d() basic operations. Failed (dist2d(0%,0%,3%,4)=[dist2d(0,0,3,4)] dist2d(1%,1%,4%,5)=[dist2d(1,1,4,5)]).;
+    @log smoke=TC001: dist2d() basic operations. Failed (dist2d(0%,0%,3%,4)=[dist2d(0,0,3,4)] dist2d(1%,1%,4%,5)=[dist2d(1,1,4,5)] zero=[dist2d(0,0,0,0)] neg=[dist2d(-3,-4,0,0)] decimal=[dist2d(0,0,1,1)] sym1=[dist2d(1,2,5,6)] sym2=[dist2d(5,6,1,2)]).;
     @trig me/tr.done
   }
 -

--- a/testcases/dist3d_fn.mux
+++ b/testcases/dist3d_fn.mux
@@ -16,14 +16,16 @@
 #
 &tr.tc001 test_dist3d_fn=
   @if cand(
-        eq(dist3d(0,0,0,1,2,2),3)
+        eq(dist3d(0,0,0,1,2,2),3),
+        eq(dist3d(0,0,0,0,0,0),0),
+        eq(dist3d(-1,-2,-2,0,0,0),3)
       )=
   {
     @log smoke=TC001: dist3d() basic operations. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC001: dist3d() basic operations. Failed (dist3d(0%,0%,0%,1%,2%,2)=[dist3d(0,0,0,1,2,2)]).;
+    @log smoke=TC001: dist3d() basic operations. Failed (dist3d(0%,0%,0%,1%,2%,2)=[dist3d(0,0,0,1,2,2)] zero=[dist3d(0,0,0,0,0,0)] neg=[dist3d(-1,-2,-2,0,0,0)]).;
     @trig me/tr.done
   }
 -


### PR DESCRIPTION
Closes #884. Partially addresses #757.

Extends the existing TC001 blocks in testcases/dist2d_fn.mux and testcases/dist3d_fn.mux with zero-distance, negative-coordinate, decimal, and symmetry coverage for the distance computations.

Validation: build succeeded; smoke 1268 succeeded / 0 failed / 0 crashes, 266/266 suites dispatched; git diff --check clean.