### PR TITLE
test: add israt() parsing-surface smoke coverage

### DIFF
--- a/testcases/israt_fn.mux
+++ b/testcases/israt_fn.mux
@@ -18,14 +18,22 @@
   @if cand(
         eq(israt(1.5), 1),
         eq(israt(1), 1),
-        eq(israt(abc), 0)
+        eq(israt(abc), 0),
+        eq(israt(1e10), 0),
+        eq(israt(-1.5), 1),
+        eq(israt(+2), 1),
+        eq(israt(.5), 1),
+        eq(israt(5.), 1),
+        eq(israt(.), 0),
+        eq(israt(-), 0),
+        eq(israt(1.2.3), 0)
       )=
   {
     @log smoke=TC001: israt() basic operations. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC001: israt() basic operations. Failed (israt(1.5)=[israt(1.5)] israt(1)=[israt(1)] israt(abc)=[israt(abc)]).;
+    @log smoke=TC001: israt() basic operations. Failed (israt(1.5)=[israt(1.5)] israt(1)=[israt(1)] israt(abc)=[israt(abc)] israt(1e10)=[israt(1e10)] israt(-1.5)=[israt(-1.5)] israt(+2)=[israt(+2)] israt(.5)=[israt(.5)] israt(5.)=[israt(5.)] israt(.)=[israt(.)] israt(-)=[israt(-)] israt(1.2.3)=[israt(1.2.3)]).;
     @trig me/tr.done
   }
 -


### PR DESCRIPTION
Closes #887. Partially addresses #757.

Adds eight parsing-surface assertions to the existing TC001 block in testcases/israt_fn.mux, covering scientific notation rejection, signed values, decimal-point asymmetry, and malformed decimal strings.

Validation: build succeeded; runtime probe confirmed the eight new values; full smoke 1269/1269 passed, 266/266 suites dispatched, 0 failures, 0 crashes; git diff --check clean.
