### PR TITLE
test: add floordiv/idiv divide-by-zero coverage

### DIFF
--- a/testcases/floordiv_fn.mux
+++ b/testcases/floordiv_fn.mux
@@ -20,8 +20,7 @@
         eq(floordiv(-10,3), -4)
       )=
   {
-    @log smoke=TC001: floordiv() basic operations. Succeeded.;
-    @trig me/tr.done
+    @log smoke=TC001: floordiv() basic operations. Succeeded.
   },
   {
     @log smoke=TC001: floordiv() basic operations. Failed (floordiv(10%,3)=[floordiv(10,3)] floordiv(-10%,3)=[floordiv(-10,3)]).;
@@ -35,15 +34,31 @@
         eq(floordiv(10,-3),-4),
         eq(floordiv(-10,-3),3),
         eq(floordiv(5.5,2),2),
-        eq(floordiv(),0),
+        strmatch(floordiv(), #-1 FUNCTION (FLOORDIV) EXPECTS 2 ARGUMENTS),
         eq(floordiv(foo,3),0)
       )=
   {
-    @log smoke=TC002: floordiv() sign and coercion cases. Succeeded.;
+    @log smoke=TC002: floordiv() sign and coercion cases. Succeeded.
+  },
+  {
+    @log smoke=TC002: floordiv() sign and coercion cases. Failed (floordiv(10%,-3)=[floordiv(10,-3)] floordiv(-10%,-3)=[floordiv(-10,-3)] floordiv(5.5%,2)=[floordiv(5.5,2)] floordiv()=[floordiv()] floordiv(foo%,3)=[floordiv(foo,3)]).
+  }
+-
+#
+# Test Case #3 - Divide-by-zero error path.
+#
+&tr.tc003 test_floordiv_fn=
+  @if cand(
+        strmatch(floordiv(10,0), #-1 DIVIDE BY ZERO),
+        strmatch(floordiv(10,abc), #-1 DIVIDE BY ZERO),
+        strmatch(floordiv(10,0.5), #-1 DIVIDE BY ZERO)
+      )=
+  {
+    @log smoke=TC003: floordiv() divide-by-zero. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC002: floordiv() sign and coercion cases. Failed (floordiv(10%,-3)=[floordiv(10,-3)] floordiv(-10%,-3)=[floordiv(-10,-3)] floordiv(5.5%,2)=[floordiv(5.5,2)] floordiv()=[floordiv()] floordiv(foo%,3)=[floordiv(foo,3)]).;
+    @log smoke=TC003: floordiv() divide-by-zero. Failed (floordiv(10%,0)=[floordiv(10,0)] floordiv(10%,abc)=[floordiv(10,abc)] floordiv(10%,0.5)=[floordiv(10,0.5)]).;
     @trig me/tr.done
   }
 -

--- a/testcases/idiv_fn.mux
+++ b/testcases/idiv_fn.mux
@@ -20,8 +20,7 @@
         eq(idiv(-10,3), -3)
       )=
   {
-    @log smoke=TC001: idiv() basic operations. Succeeded.;
-    @trig me/tr.done
+    @log smoke=TC001: idiv() basic operations. Succeeded.
   },
   {
     @log smoke=TC001: idiv() basic operations. Failed (idiv(10%,3)=[idiv(10,3)] idiv(-10%,3)=[idiv(-10,3)]).;
@@ -35,15 +34,31 @@
         eq(idiv(10,-3),-3),
         eq(idiv(-10,-3),3),
         eq(idiv(5.5,2),2),
-        eq(idiv(),0),
+        strmatch(idiv(), #-1 FUNCTION (IDIV) EXPECTS 2 ARGUMENTS),
         eq(idiv(foo,3),0)
       )=
   {
-    @log smoke=TC002: idiv() sign and coercion cases. Succeeded.;
+    @log smoke=TC002: idiv() sign and coercion cases. Succeeded.
+  },
+  {
+    @log smoke=TC002: idiv() sign and coercion cases. Failed (idiv(10%,-3)=[idiv(10,-3)] idiv(-10%,-3)=[idiv(-10,-3)] idiv(5.5%,2)=[idiv(5.5,2)] idiv()=[idiv()] idiv(foo%,3)=[idiv(foo,3)]).
+  }
+-
+#
+# Test Case #3 - Divide-by-zero error path.
+#
+&tr.tc003 test_idiv_fn=
+  @if cand(
+        strmatch(idiv(10,0), #-1 DIVIDE BY ZERO),
+        strmatch(idiv(10,abc), #-1 DIVIDE BY ZERO),
+        strmatch(idiv(10,0.5), #-1 DIVIDE BY ZERO)
+      )=
+  {
+    @log smoke=TC003: idiv() divide-by-zero. Succeeded.;
     @trig me/tr.done
   },
   {
-    @log smoke=TC002: idiv() sign and coercion cases. Failed (idiv(10%,-3)=[idiv(10,-3)] idiv(-10%,-3)=[idiv(-10,-3)] idiv(5.5%,2)=[idiv(5.5,2)] idiv()=[idiv()] idiv(foo%,3)=[idiv(foo,3)]).;
+    @log smoke=TC003: idiv() divide-by-zero. Failed (idiv(10%,0)=[idiv(10,0)] idiv(10%,abc)=[idiv(10,abc)] idiv(10%,0.5)=[idiv(10,0.5)]).;
     @trig me/tr.done
   }
 -


### PR DESCRIPTION
Closes #894. Partially addresses #893.

Adds TC003 to both testcases/floordiv_fn.mux and testcases/idiv_fn.mux for the divide-by-zero path: literal zero, non-numeric divisor coercing to zero, and decimal divisor coercing to zero.

Also fixes the TC002 assertions intentionally: the prior eq(floordiv(),0) / eq(idiv(),0) checks passed through numeric coercion of the arity error string, so they now pin the exact arity errors instead.

Also fixes the trigger chain intentionally: TC001/TC002 are now non-terminal and only the new TC003 triggers tr.done from both branches, which is required for TC003 to run as part of the suite.

Validation: build succeeded; runtime probe confirmed all six divide-by-zero values and both arity-error strings; full smoke 1273/1273 passed, 266/266 suites dispatched, 0 failures, 0 crashes; TC002 and TC003 log lines appear for both files; git diff --check clean.
